### PR TITLE
opening file is too slow.

### DIFF
--- a/ftplugin/perl/perlomni.vim
+++ b/ftplugin/perl/perlomni.vim
@@ -5,8 +5,8 @@
 " Email:   cornelius.howl@gmail.com
 " Version: 1.75
 let s:debug_flag = 0
-runtime 'plugin/perlomni-data.vim'
-runtime 'plugin/perlomni-util.vim'
+runtime plugin/perlomni-data.vim
+runtime plugin/perlomni-util.vim
 
 let s:mod_pattern = '[a-zA-Z][a-zA-Z0-9:]\+'
 


### PR DESCRIPTION
running 'runtime' is too slow on my environment.
Then I delete quote from 'runtime' arg.

profile result:

```
SCRIPT  $HOME/.vim/bundle/perlomni.vim/ftplugin/perl/perlomni.vim
Sourced 1 time
Total time:  22.710025
 Self time:   0.047645

count  total (s)   self (s)
                            " vim:fdm=marker:sw=4:et:fdl=0:
                            "
                            " Plugin:  perlomni.vim
                            " Author:  Cornelius
                            " Email:   cornelius.howl@gmail.com
                            " Version: 1.75
    1              0.000006 let s:debug_flag = 0
    1  10.307752   0.008731 runtime 'plugin/perlomni-data.vim'
    1  12.371138   0.008729 runtime 'plugin/perlomni-util.vim'

    1              0.000021 let s:mod_pattern = '[a-zA-Z][a-zA-Z0-9:]\+'

                            " Check installed scripts {{{
```

my vim environment:
OS: debian sid 64bit
VIM: vim-gnome 7.3.280-1 (debian package)

```
$vim --version
VIM - Vi IMproved 7.3 (2010 Aug 15, compiled Aug 15 2011 11:18:14)
Included patches: 1-280
Modified by pkg-vim-maintainers@lists.alioth.debian.org
Compiled by buildd@
Huge version with GTK2-GNOME GUI.  Features included (+) or not (-):
+arabic +autocmd +balloon_eval +browse ++builtin_terms +byte_offset +cindent 
+clientserver +clipboard +cmdline_compl +cmdline_hist +cmdline_info +comments 
+conceal +cryptv +cscope +cursorbind +cursorshape +dialog_con_gui +diff 
+digraphs +dnd -ebcdic +emacs_tags +eval +ex_extra +extra_search +farsi 
+file_in_path +find_in_path +float +folding -footer +fork() +gettext 
-hangul_input +iconv +insert_expand +jumplist +keymap +langmap +libcall 
+linebreak +lispindent +listcmds +localmap +lua +menu +mksession +modify_fname 
+mouse +mouseshape +mouse_dec +mouse_gpm -mouse_jsbterm +mouse_netterm 
-mouse_sysmouse +mouse_xterm +multi_byte +multi_lang -mzscheme +netbeans_intg 
+path_extra +perl +persistent_undo +postscript +printer +profile +python 
-python3 +quickfix +reltime +rightleft +ruby +scrollbind +signs +smartindent 
-sniff +startuptime +statusline -sun_workshop +syntax +tag_binary 
+tag_old_static -tag_any_white +tcl +terminfo +termresponse +textobjects +title
 +toolbar +user_commands +vertsplit +virtualedit +visual +visualextra +viminfo 
+vreplace +wildignore +wildmenu +windows +writebackup +X11 -xfontset +xim 
+xsmp_interact +xterm_clipboard -xterm_save 
   system vimrc file: "$VIM/vimrc"
     user vimrc file: "$HOME/.vimrc"
      user exrc file: "$HOME/.exrc"
  system gvimrc file: "$VIM/gvimrc"
    user gvimrc file: "$HOME/.gvimrc"
    system menu file: "$VIMRUNTIME/menu.vim"
  fall-back for $VIM: "/usr/share/vim"
Compilation: gcc -c -I. -Iproto -DHAVE_CONFIG_H -DFEAT_GUI_GTK  -pthread -I/usr/include/gtk-2.0 -I/usr/lib/x86_64-linux-gnu/gtk-2.0/include -I/usr/include/atk-1.0 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/pango-1.0 -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng12 -I/usr/include/cairo -I/usr/include/gio-unix-2.0/ -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include   -DORBIT2=1 -pthread -D_REENTRANT -I/usr/include/gtk-2.0 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/pango-1.0 -I/usr/include/gail-1.0 -I/usr/include/freetype2 -I/usr/include/atk-1.0 -I/usr/lib/x86_64-linux-gnu/gtk-2.0/include -I/usr/include/pixman-1 -I/usr/include/libpng12 -I/usr/include/libgnomeui-2.0 -I/usr/include/libart-2.0 -I/usr/include/gconf/2 -I/usr/include/gnome-keyring-1 -I/usr/include/libgnome-2.0 -I/usr/include/libbonoboui-2.0 -I/usr/include/libgnomecanvas-2.0 -I/usr/include/gnome-vfs-2.0 -I/usr/lib/gnome-vfs-2.0/include -I/usr/include/orbit-2.0 -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/libbonobo-2.0 -I/usr/include/bonobo-activation-2.0 -I/usr/include/libxml2 -I/usr/include/cairo -I/usr/include/gio-unix-2.0/     -Wall -g -O2 -D_FORTIFY_SOURCE=1     -I/usr/include/tcl8.5  -D_REENTRANT=1  -D_THREAD_SAFE=1  -D_LARGEFILE64_SOURCE=1  
Linking: gcc   -L.  -rdynamic -Wl,-export-dynamic  -Wl,-E   -Wl,--as-needed -o vim   -pthread -lgtk-x11-2.0 -lgdk-x11-2.0 -latk-1.0 -lgio-2.0 -lpangoft2-1.0 -lpangocairo-1.0 -lgdk_pixbuf-2.0 -lm -lcairo -lpango-1.0 -lfreetype -lfontconfig -lgobject-2.0 -lgmodule-2.0 -lgthread-2.0 -lrt -lglib-2.0     -lgnomeui-2 -lSM -lICE -lbonoboui-2 -lgnomevfs-2 -lgnomecanvas-2 -lgnome-2 -lpopt -lbonobo-2 -lbonobo-activation -lORBit-2 -lart_lgpl_2 -lgtk-x11-2.0 -lgdk-x11-2.0 -latk-1.0 -lgio-2.0 -lpangoft2-1.0 -lpangocairo-1.0 -lgdk_pixbuf-2.0 -lm -lcairo -lpango-1.0 -lfreetype -lfontconfig -lgconf-2 -lgmodule-2.0 -lgobject-2.0 -lgthread-2.0 -lrt -lglib-2.0   -lSM -lICE -lXpm -lXt -lX11 -lXdmcp -lSM -lICE -lm -lncurses -lnsl  -lselinux  -lacl -lattr -lgpm  -L/usr/lib -llua5.1  -Wl,-E  -fstack-protector -L/usr/local/lib  -L/usr/lib/perl/5.12/CORE -lperl -ldl -lm -lpthread -lcrypt -L/usr/lib/python2.6/config -lpython2.6 -lpthread -ldl -lutil -lm -Xlinker -export-dynamic -Wl,-O1 -Wl,-Bsymbolic-functions  -L/usr/lib -ltcl8.5 -ldl -lpthread -lieee -lm -lruby1.8 -lpthread -lrt -ldl -lcrypt -lm  -L/usr/lib
```
