### PR TITLE
Fix path split.

### DIFF
--- a/ftplugin/perl/perlomni.vim
+++ b/ftplugin/perl/perlomni.vim
@@ -174,7 +174,7 @@ fun! s:locateClassFile(class)
         return l:cache
     endif
 
-    let paths = split(&path,',')
+    let paths = map(split(&path, '\\\@<![, ]'), 'substitute(v:val, ''\\\([, ]\)'', ''\1'', ''g'')')
     if g:perlomni_use_perlinc || &filetype != 'perl'
         let paths = split( s:system(g:perlomni_perl, '-e', 'print join(",",@INC)') ,',')
     endif


### PR DESCRIPTION
`path` split by `,` , if fails error of included path of ` `(whitespace) or`,`.

> `:help path`
> 
> Spaces can also be used to separate directory names (for backwards
> compatibility with version 3.0).  To have a space in a directory
> name, precede it with an extra backslash, and escape the space:
> 
> ``` vim
> :set path=.,/dir/with\\\ space
> ```
> 
> To include a comma in a directory name precede it with an extra
> backslash:
> 
> ``` vim
> :set path=.,/dir/with\\,comma
> ```
